### PR TITLE
OTS-2325 | Empty array gets passed to markers param by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 
 /vendor
 /composer.lock
+
+.idea/

--- a/Classes/ViewHelpers/LabelViewHelper.php
+++ b/Classes/ViewHelpers/LabelViewHelper.php
@@ -42,9 +42,10 @@ class LabelViewHelper extends AbstractViewHelper
      */
     public function render()
     {
+
         return $this->label->get(
             trim($this->arguments['key']),
-            $this->arguments['markers'],
+            (($this->arguments['markers']) ? $this->arguments['markers'] : []),
             $this->arguments['returnKeyOnEmpty']
         );
     }


### PR DESCRIPTION
## Tracker/JIRA Issue
* https://jira.3ev.info/browse/OTS-2325

## Dev Notes
* As part of OTS-2325, it was requested that an empty array gets passed to the markers parameter by default

## Deployment Steps
* No additional steps required